### PR TITLE
Implement ExprPlugin

### DIFF
--- a/docs/basics/utilities.md
+++ b/docs/basics/utilities.md
@@ -175,3 +175,15 @@ Checks whether objects are instances of the given java types.
 Returns a reference to the class from the given java type. Returns an object of type `java.lang.Class`.
 This expression also supports primitive types, which doesn't require an import.
 
+## Plugin instance
+
+{% code-tabs %}
+{% code-tabs-item title="Syntax" %}
+```text
+[(an|the)] instance of [the] plugin %javatype/string%
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+Returns the instance of the given plugin (either the name as a string, or the plugin class).
+

--- a/src/main/java/com/btk5h/skriptmirror/skript/ExprPlugin.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/ExprPlugin.java
@@ -2,47 +2,60 @@ package com.btk5h.skriptmirror.skript;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import com.btk5h.skriptmirror.JavaType;
 import com.btk5h.skriptmirror.ObjectWrapper;
+import com.btk5h.skriptmirror.skript.custom.CustomImport;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.eclipse.jdt.annotation.NonNull;
-
-import java.util.Arrays;
-import java.util.Optional;
 
 public class ExprPlugin extends SimplePropertyExpression<Object, ObjectWrapper> {
 
   static {
-    Skript.registerExpression(ExprPlugin.class, ObjectWrapper.class, ExpressionType.PROPERTY, "[an] instance of [the] plugin %javatype/string%");
+    Skript.registerExpression(ExprPlugin.class, ObjectWrapper.class, ExpressionType.PROPERTY, "[(an|the)] instance of [the] plugin %javatype/string%");
   }
 
-  // PluginManager#getPlugin is case-sensitive, but we don't want scripters to deal with that
-  private Optional<String> findPluginCaseInsensitive(String pluginName) {
-    return Arrays.stream(Bukkit.getPluginManager().getPlugins())
-        .map(Plugin::getName)
-        .filter(pluginName::equalsIgnoreCase)
-        .findFirst();
+  @Override
+  public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+    super.init(exprs, matchedPattern, isDelayed, parseResult);
+
+    if (exprs[0] instanceof CustomImport.ImportHandler) {
+      JavaType javaType = ((CustomImport.ImportHandler) exprs[0]).getJavaType();
+      Class<?> clazz = javaType.getJavaClass();
+
+      if (!JavaPlugin.class.isAssignableFrom(clazz) || JavaPlugin.class.equals(clazz)) {
+        Skript.error("The class " + clazz.getSimpleName() + " is not a plugin class");
+        return false;
+      }
+    }
+
+    return true;
   }
 
   @Override
   public ObjectWrapper convert(Object plugin) {
     if (plugin instanceof String) {
-      PluginManager pluginManager = Bukkit.getPluginManager();
-      return findPluginCaseInsensitive((String) plugin)
-          .map(pluginManager::getPlugin)
-          .map(ObjectWrapper::create)
-          .orElse(null);
+      String pluginName = (String) plugin;
+      for (Plugin pluginInstance : Bukkit.getPluginManager().getPlugins()) {
+        if (pluginInstance.getName().equalsIgnoreCase(pluginName)) {
+          return ObjectWrapper.create(pluginInstance);
+        }
+      }
+
+      return null;
     } else {
-      try {
-        Class<?> clazz = ((JavaType) plugin).getJavaClass();
-        return ObjectWrapper.create(JavaPlugin.getProvidingPlugin(clazz));
-      } catch (IllegalArgumentException | IllegalStateException e) {
+      Class<?> clazz = ((JavaType) plugin).getJavaClass();
+
+      if (!JavaPlugin.class.isAssignableFrom(clazz) || JavaPlugin.class.equals(clazz)) {
         return null;
       }
+
+      return ObjectWrapper.create(JavaPlugin.getPlugin(clazz.asSubclass(JavaPlugin.class)));
     }
   }
 

--- a/src/main/java/com/btk5h/skriptmirror/skript/ExprPlugin.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/ExprPlugin.java
@@ -1,0 +1,61 @@
+package com.btk5h.skriptmirror.skript;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.ExpressionType;
+import com.btk5h.skriptmirror.JavaType;
+import com.btk5h.skriptmirror.ObjectWrapper;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.eclipse.jdt.annotation.NonNull;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public class ExprPlugin extends SimplePropertyExpression<Object, ObjectWrapper> {
+
+  static {
+    Skript.registerExpression(ExprPlugin.class, ObjectWrapper.class, ExpressionType.PROPERTY, "[an] instance of [the] plugin %javatype/string%");
+  }
+
+  // PluginManager#getPlugin is case-sensitive, but we don't want scripters to deal with that
+  private Optional<String> findPluginCaseInsensitive(String pluginName) {
+    return Arrays.stream(Bukkit.getPluginManager().getPlugins())
+        .map(Plugin::getName)
+        .filter(pluginName::equalsIgnoreCase)
+        .findFirst();
+  }
+
+  @Override
+  public ObjectWrapper convert(Object plugin) {
+    if (plugin instanceof String) {
+      PluginManager pluginManager = Bukkit.getPluginManager();
+      return findPluginCaseInsensitive((String) plugin)
+          .map(pluginManager::getPlugin)
+          .map(ObjectWrapper::create)
+          .orElse(null);
+    } else {
+      try {
+        Class<?> clazz = ((JavaType) plugin).getJavaClass();
+        return ObjectWrapper.create(JavaPlugin.getProvidingPlugin(clazz));
+      } catch (IllegalArgumentException | IllegalStateException e) {
+        return null;
+      }
+    }
+  }
+
+  @Override
+  @NonNull
+  public Class<? extends ObjectWrapper> getReturnType() {
+    return ObjectWrapper.class;
+  }
+
+  @Override
+  @NonNull
+  protected String getPropertyName() {
+    return "plugin instance";
+  }
+
+}


### PR DESCRIPTION
Adds `ExprPlugin` which allows direct access to javaplugin instances either by name or from a javatype. This makes it easier to get an instance of a plugin without having to import org.bukkit.Bukkit and grab it from the PluginManager. Test script:
```
import:
	ch.njol.skript.Skript as pluginMainClass
	ch.njol.skript.ScriptLoader as otherPluginClass
	java.lang.String as notAPluginClass
 
on load:
	broadcast "pluginMainClass: %instance of plugin pluginMainClass%"
	broadcast "otherPluginClass: %instance of plugin otherPluginClass%"
	broadcast "notAPluginClass: %instance of plugin notAPluginClass%"
	broadcast "Null: %instance of plugin {_null}%"
	broadcast "Case insensitive (sKrIpT): %instance of plugin "sKrIpT"%"
	broadcast "Case sensitive (Skript): %instance of plugin "Skript"%"
	broadcast "Call instance method of plugin instance: %(instance of plugin "Skript").getUpdater()%"
```
Output:
```
[02:20:49 INFO]: [Skript] Reloading test.sk...
[02:20:49 INFO]: pluginMainClass: Skript v2.6.1
[02:20:49 INFO]: otherPluginClass: Skript v2.6.1
[02:20:49 INFO]: notAPluginClass: <none>
[02:20:49 INFO]: Null: <none>
[02:20:49 INFO]: Case insensitive (sKrIpT): Skript v2.6.1
[02:20:49 INFO]: Case sensitive (Skript): Skript v2.6.1
[02:20:49 INFO]: Call instance method of plugin instance: ch.njol.skript.SkriptUpdater@219b27ec
[02:20:49 INFO]: [Skript] Successfully reloaded test.sk. (27ms)
```