### PR TITLE
Make EffReturn be ignored if not in correct section

### DIFF
--- a/src/main/java/com/btk5h/skriptmirror/skript/custom/expression/EffReturn.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/custom/expression/EffReturn.java
@@ -38,10 +38,8 @@ public class EffReturn extends Effect {
     boolean isContinuable = CollectionUtils.containsAnySuperclass(new Class[]{Continuable.class}, getParser().getCurrentEvents());
 
     if (!getParser().isCurrentEvent(ExpressionGetEvent.class, ConstantGetEvent.class, SectionEvent.class)
-        && !isContinuable) {
-      Skript.error("The return effect can only be used in functions, custom expressions, sections, custom syntax parse sections and custom conditions");
+        && !isContinuable)
       return false;
-    }
 
     if (isContinuable) {
       expr = expr.getConvertedExpression(Boolean.class);


### PR DESCRIPTION
Make EffReturn be ignored if not in correct section.
Currently skript-reflect will override Skript's own EffReturn. Even when in a function Structure.

To avoid this, and any other possible causes, skript-reflect should just silently return false and not error, because erroring makes Skript stop searching for possible syntaxes.