### PR TITLE
Update to 2.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,6 @@ compileJava   {
 
 dependencies {
   implementation 'org.spigotmc:spigot-api:1.13.2-R0.1-SNAPSHOT'
-  implementation 'com.github.SkriptLang:Skript:2.7.1'
+  implementation 'com.github.SkriptLang:Skript:2.8.0-pre1'
   implementation 'org.eclipse.jdt:org.eclipse.jdt.annotation:1.1.0'
 }

--- a/src/main/java/com/btk5h/skriptmirror/ParseOrderWorkarounds.java
+++ b/src/main/java/com/btk5h/skriptmirror/ParseOrderWorkarounds.java
@@ -38,11 +38,11 @@ public class ParseOrderWorkarounds {
 
   public static void reorderSyntax() {
     for (String c : PARSE_ORDER) {
-      ensureLast(Skript.getStatements(), o -> o.c.getName().equals(c));
-      ensureLast(Skript.getConditions(), o -> o.c.getName().equals(c));
-      ensureLast(Skript.getEffects(), o -> o.c.toString().equals(c));
-      ensureLast(SkriptReflection.getExpressions(), o -> o.c.getName().equals(c));
-      ensureLast(Skript.getEvents(), o -> o.c.getName().equals(c));
+      ensureLast(Skript.getStatements(), o -> o.getElementClass().getName().equals(c));
+      ensureLast(Skript.getConditions(), o -> o.getElementClass().getName().equals(c));
+      ensureLast(Skript.getEffects(), o -> o.getElementClass().toString().equals(c));
+      ensureLast(SkriptReflection.getExpressions(), o -> o.getElementClass().getName().equals(c));
+      ensureLast(Skript.getEvents(), o -> o.getElementClass().getName().equals(c));
     }
   }
 

--- a/src/main/java/com/btk5h/skriptmirror/util/SkriptReflection.java
+++ b/src/main/java/com/btk5h/skriptmirror/util/SkriptReflection.java
@@ -9,7 +9,6 @@ import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.DefaultExpression;
 import ch.njol.skript.lang.ExpressionInfo;
-import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.SyntaxElementInfo;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.structures.StructOptions;
@@ -36,7 +35,6 @@ public class SkriptReflection {
   private static Method VARIABLES_MAP_COPY;
   private static Field DEFAULT_EXPRESSION;
   private static Field PARSED_VALUE;
-  private static Method PARSE_I;
   private static Field EXPRESSIONS;
   private static Field OPTIONS;
 
@@ -99,18 +97,6 @@ public class SkriptReflection {
     } catch (NoSuchFieldException e) {
       warning("Skript's parsed value field could not be resolved, " +
           "therefore and/or warnings won't be suppressed");
-    }
-
-    try {
-      if (Skript.getVersion().compareTo(2, 8) >= 0) {
-          _METHOD = SkriptParser.class.getDeclaredMethod("parse_i", String.class);
-      } else {
-          _METHOD = SkriptParser.class.getDeclaredMethod("parse_i", String.class, int.class, int.class);
-      }
-      _METHOD.setAccessible(true);
-      PARSE_I = _METHOD;
-    } catch (NoSuchMethodException e) {
-      warning("Skript's parse_i method could not be resolved, therefore prioritized loading won't work.");
     }
 
     try {
@@ -282,20 +268,6 @@ public class SkriptReflection {
       } catch (IllegalAccessException e) {
         throw new RuntimeException();
       }
-    }
-  }
-
-  /**
-   * Executes {@link SkriptParser}'s {@code parse_i} method with the given arguments.
-   */
-  public static SkriptParser.ParseResult parse_i(SkriptParser skriptParser, String pattern, int i, int j) {
-    if (PARSE_I == null)
-      return null;
-
-    try {
-      return (SkriptParser.ParseResult) PARSE_I.invoke(skriptParser, pattern, i, j);
-    } catch (IllegalAccessException | InvocationTargetException e) {
-      throw new RuntimeException(e);
     }
   }
 

--- a/src/main/java/com/btk5h/skriptmirror/util/SkriptReflection.java
+++ b/src/main/java/com/btk5h/skriptmirror/util/SkriptReflection.java
@@ -102,7 +102,7 @@ public class SkriptReflection {
     }
 
     try {
-      _METHOD = SkriptParser.class.getDeclaredMethod("parse_i", String.class, int.class, int.class);
+      _METHOD = SkriptParser.class.getDeclaredMethod("parse_i", String.class);
       _METHOD.setAccessible(true);
       PARSE_I = _METHOD;
     } catch (NoSuchMethodException e) {

--- a/src/main/java/com/btk5h/skriptmirror/util/SkriptReflection.java
+++ b/src/main/java/com/btk5h/skriptmirror/util/SkriptReflection.java
@@ -15,8 +15,8 @@ import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.structures.StructOptions;
 import ch.njol.skript.variables.Variables;
 import com.btk5h.skriptmirror.SkriptMirror;
-import org.skriptlang.reflect.syntax.event.elements.ExprReplacedEventValue;
 import org.bukkit.event.Event;
+import org.skriptlang.reflect.syntax.event.elements.ExprReplacedEventValue;
 import org.skriptlang.skript.lang.script.Script;
 
 import java.lang.reflect.Field;
@@ -102,7 +102,11 @@ public class SkriptReflection {
     }
 
     try {
-      _METHOD = SkriptParser.class.getDeclaredMethod("parse_i", String.class);
+      if (Skript.getVersion().compareTo(2, 8) >= 0) {
+          _METHOD = SkriptParser.class.getDeclaredMethod("parse_i", String.class);
+      } else {
+          _METHOD = SkriptParser.class.getDeclaredMethod("parse_i", String.class, int.class, int.class);
+      }
       _METHOD.setAccessible(true);
       PARSE_I = _METHOD;
     } catch (NoSuchMethodException e) {

--- a/src/main/java/org/skriptlang/reflect/syntax/condition/elements/StructCustomCondition.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/condition/elements/StructCustomCondition.java
@@ -2,7 +2,6 @@ package org.skriptlang.reflect.syntax.condition.elements;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.ClassInfo;
-import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Literal;
@@ -13,9 +12,9 @@ import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.util.Utils;
-import org.skriptlang.reflect.syntax.CustomSyntaxStructure;
 import com.btk5h.skriptmirror.skript.custom.SyntaxParseEvent;
 import com.btk5h.skriptmirror.util.SkriptUtil;
+import org.skriptlang.reflect.syntax.CustomSyntaxStructure;
 import org.skriptlang.reflect.syntax.condition.ConditionCheckEvent;
 import org.skriptlang.reflect.syntax.condition.ConditionSyntaxInfo;
 import org.skriptlang.skript.lang.entry.EntryContainer;
@@ -56,7 +55,7 @@ public class StructCustomCondition extends CustomSyntaxStructure<ConditionSyntax
   static {
     Skript.registerCondition(CustomCondition.class);
     Optional<SyntaxElementInfo<? extends Condition>> info = Skript.getConditions().stream()
-        .filter(i -> i.c == CustomCondition.class)
+        .filter(i -> i.getElementClass() == CustomCondition.class)
         .findFirst();
     info.ifPresent(dataTracker::setInfo);
 

--- a/src/main/java/org/skriptlang/reflect/syntax/effect/elements/StructCustomEffect.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/effect/elements/StructCustomEffect.java
@@ -1,7 +1,6 @@
 package org.skriptlang.reflect.syntax.effect.elements;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Literal;
@@ -11,9 +10,9 @@ import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.log.SkriptLogger;
-import org.skriptlang.reflect.syntax.CustomSyntaxStructure;
 import com.btk5h.skriptmirror.skript.custom.SyntaxParseEvent;
 import com.btk5h.skriptmirror.util.SkriptUtil;
+import org.skriptlang.reflect.syntax.CustomSyntaxStructure;
 import org.skriptlang.reflect.syntax.effect.EffectSyntaxInfo;
 import org.skriptlang.reflect.syntax.effect.EffectTriggerEvent;
 import org.skriptlang.skript.lang.entry.EntryContainer;
@@ -51,7 +50,7 @@ public class StructCustomEffect extends CustomSyntaxStructure<EffectSyntaxInfo> 
   static {
     Skript.registerEffect(CustomEffect.class);
     Optional<SyntaxElementInfo<? extends Effect>> info = Skript.getEffects().stream()
-      .filter(i -> i.c == CustomEffect.class)
+      .filter(i -> i.getElementClass() == CustomEffect.class)
       .findFirst();
     info.ifPresent(dataTracker::setInfo);
 

--- a/src/main/java/org/skriptlang/reflect/syntax/event/EventSyntaxInfo.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/event/EventSyntaxInfo.java
@@ -13,8 +13,6 @@ public class EventSyntaxInfo extends CustomSyntaxStructure.SyntaxData {
   }
 
   public static EventSyntaxInfo create(Script script, String pattern, int matchedPattern) {
-    pattern = "[on] " + pattern;
-
     return new EventSyntaxInfo(script, SkriptMirrorUtil.preprocessPattern(pattern), matchedPattern);
   }
 

--- a/src/main/java/org/skriptlang/reflect/syntax/event/EventSyntaxInfo.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/event/EventSyntaxInfo.java
@@ -1,8 +1,7 @@
 package org.skriptlang.reflect.syntax.event;
 
-import ch.njol.skript.lang.SkriptEventInfo;
-import org.skriptlang.reflect.syntax.CustomSyntaxStructure;
 import com.btk5h.skriptmirror.util.SkriptMirrorUtil;
+import org.skriptlang.reflect.syntax.CustomSyntaxStructure;
 import org.skriptlang.skript.lang.script.Script;
 
 import java.util.Objects;
@@ -14,7 +13,7 @@ public class EventSyntaxInfo extends CustomSyntaxStructure.SyntaxData {
   }
 
   public static EventSyntaxInfo create(Script script, String pattern, int matchedPattern) {
-    pattern = "[on] " + pattern + SkriptEventInfo.EVENT_PRIORITY_SYNTAX;
+    pattern = "[on] " + pattern;
 
     return new EventSyntaxInfo(script, SkriptMirrorUtil.preprocessPattern(pattern), matchedPattern);
   }

--- a/src/main/java/org/skriptlang/reflect/syntax/event/elements/StructCustomEvent.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/event/elements/StructCustomEvent.java
@@ -57,7 +57,7 @@ public class StructCustomEvent extends CustomSyntaxStructure<EventSyntaxInfo> {
   static {
     Skript.registerEvent("custom event", CustomEvent.class, BukkitCustomEvent.class);
     Optional<SkriptEventInfo<?>> info = Skript.getEvents().stream()
-      .filter(i -> i.c == CustomEvent.class)
+      .filter(i -> i.getElementClass() == CustomEvent.class)
       .findFirst();
     info.ifPresent(dataTracker::setInfo);
 

--- a/src/main/java/org/skriptlang/reflect/syntax/expression/elements/EffReturn.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/expression/elements/EffReturn.java
@@ -97,7 +97,7 @@ public class EffReturn extends Effect {
       if (parent instanceof SecLoop) {
         ((SecLoop) parent).exit(e);
       } else if (parent instanceof SecWhile) {
-        ((SecWhile) parent).reset();
+        ((SecWhile) parent).exit(e);
       }
       parent = parent.getParent();
     }

--- a/src/main/java/org/skriptlang/reflect/syntax/expression/elements/StructCustomConstant.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/expression/elements/StructCustomConstant.java
@@ -44,7 +44,7 @@ public class StructCustomConstant extends CustomSyntaxStructure<ConstantSyntaxIn
     Skript.registerExpression(CustomExpression.class, Object.class, ExpressionType.SIMPLE);
     Optional<ExpressionInfo<?, ?>> info = StreamSupport.stream(
         Spliterators.spliteratorUnknownSize(Skript.getExpressions(), Spliterator.ORDERED), false)
-        .filter(i -> i.c == CustomExpression.class)
+        .filter(i -> i.getElementClass() == CustomExpression.class)
         .findFirst();
     info.ifPresent(dataTracker::setInfo);
   }

--- a/src/main/java/org/skriptlang/reflect/syntax/expression/elements/StructCustomExpression.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/expression/elements/StructCustomExpression.java
@@ -93,7 +93,7 @@ public class StructCustomExpression extends CustomSyntaxStructure<ExpressionSynt
     Skript.registerExpression(CustomExpression.class, Object.class, ExpressionType.PATTERN_MATCHES_EVERYTHING);
     Optional<ExpressionInfo<?, ?>> info = StreamSupport.stream(
         Spliterators.spliteratorUnknownSize(Skript.getExpressions(), Spliterator.ORDERED), false)
-        .filter(i -> i.c == CustomExpression.class)
+        .filter(i -> i.getElementClass() == CustomExpression.class)
         .findFirst();
     info.ifPresent(dataTracker::setInfo);
 


### PR DESCRIPTION
Sorry, thought I was making a branch on my own fork!

This replaces all uses of `SyntaxElementInfo#c` with `SyntaxElementInfo#getElementClass()`, since the field is renamed in 2.8 and will be private in 2.9.

Removes the event-priority addition for custom events in favor of 2.8's automatic handling.

Small change to effreturn to handle exiting while loops properly.

Closes #80 