### PR TITLE
Ensure lastWhich is set correctly for CustomEvent parsing

### DIFF
--- a/src/main/java/org/skriptlang/reflect/syntax/event/elements/CustomEvent.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/event/elements/CustomEvent.java
@@ -77,6 +77,14 @@ public class CustomEvent extends SkriptEvent {
   }
 
   @Override
+  public boolean load() {
+    CustomEvent.setLastWhich(which);
+    boolean parsed = super.load();
+    CustomEvent.setLastWhich(null);
+    return parsed;
+  }
+
+  @Override
   public boolean check(Event e) {
     BukkitCustomEvent bukkitCustomEvent = (BukkitCustomEvent) e;
     if (!bukkitCustomEvent.getName().equalsIgnoreCase(StructCustomEvent.nameValues.get(which)))


### PR DESCRIPTION
Previously, lastWhich was set when parsing the custom event definition, but not when actually using `on my event`, resulting in things like `usable in` and event-values to error as they didn't know what event they were being used in.

This ensures lastWhich is set when the parsing of the events themselves occurs.

Fixes #91 