### PR TITLE
Added sync-only entry in custom events (attempt #2)

### DIFF
--- a/src/main/java/org/skriptlang/reflect/syntax/event/SyncOnlyEntryData.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/event/SyncOnlyEntryData.java
@@ -1,0 +1,40 @@
+package org.skriptlang.reflect.syntax.event;
+
+import ch.njol.skript.ScriptLoader;
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.Node;
+import ch.njol.skript.config.SimpleNode;
+import org.eclipse.jdt.annotation.Nullable;
+import org.skriptlang.skript.lang.entry.KeyValueEntryData;
+
+public class SyncOnlyEntryData extends KeyValueEntryData<Boolean> {
+
+  public SyncOnlyEntryData(String key, @Nullable Boolean defaultValue, boolean optional) {
+    super(key, defaultValue, optional);
+  }
+
+  @Override
+  @Nullable
+  protected Boolean getValue(String value) {
+    if (!(value.equalsIgnoreCase("false") || value.equalsIgnoreCase("true"))) {
+        Skript.error("Sync only entry can be only true or false.");
+        return null;
+    }
+    return Boolean.valueOf(value);
+  }
+
+  @Override
+  public final boolean canCreateWith(Node node) {
+    if (!(node instanceof SimpleNode))
+      return false;
+    String key = node.getKey();
+    if (key == null)
+      return false;
+    return canCreateWith(ScriptLoader.replaceOptions(key));
+  }
+
+  protected boolean canCreateWith(String node) {
+    return node.startsWith(getKey() + getSeparator());
+  }
+
+}

--- a/src/main/java/org/skriptlang/reflect/syntax/event/elements/CustomEvent.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/event/elements/CustomEvent.java
@@ -31,7 +31,8 @@ public class CustomEvent extends SkriptEvent {
   private Expression<?>[] exprs;
   private SkriptParser.ParseResult parseResult;
   private Object variablesMap;
-
+  private boolean syncOnly;
+  
   @Override
   public boolean init(Literal<?>[] args, int matchedPattern, SkriptParser.ParseResult parseResult) {
     which = StructCustomEvent.lookup(SkriptUtil.getCurrentScript(), matchedPattern);
@@ -39,7 +40,7 @@ public class CustomEvent extends SkriptEvent {
     if (which == null) {
       return false;
     }
-
+    
     this.exprs = Arrays.stream(args)
       .map(SkriptUtil::defendExpression)
       .toArray(Expression[]::new);
@@ -48,7 +49,9 @@ public class CustomEvent extends SkriptEvent {
     if (!SkriptUtil.canInitSafely(this.exprs)) {
       return false;
     }
-
+    
+    syncOnly = StructCustomEvent.syncOnly.get(which);
+    
     Boolean bool = StructCustomEvent.parseSectionLoaded.get(which);
     if (bool != null && !bool) {
       Skript.error("You can't use custom events with parse sections before they're loaded.");
@@ -83,7 +86,12 @@ public class CustomEvent extends SkriptEvent {
     CustomEvent.setLastWhich(null);
     return parsed;
   }
-
+  
+  @Override
+  public boolean canExecuteAsynchronously() {
+    return !syncOnly;
+  }
+  
   @Override
   public boolean check(Event e) {
     BukkitCustomEvent bukkitCustomEvent = (BukkitCustomEvent) e;


### PR DESCRIPTION
In general, at the time of declaring a custom event, you can specify whether the skript should process this event only synchronously.
ex:
```
custom event "evt"
   pattern: "my_evt"
   sync-only: true
  #sync only: true (second pattern)
```
Initially, now, any custom event can be processed asynchronously (for backwards compatability), unless 'sync only: true' is specified
Why not `allow async`, I thought that since initially any event is now processed asynchronously (if possible), then `sync only` sounds more logical.