### PR TITLE
This PR fixes java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0

### DIFF
--- a/src/main/java/com/btk5h/skriptmirror/skript/reflect/sections/Section.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/reflect/sections/Section.java
@@ -34,7 +34,7 @@ public class Section {
     for (int i = 0; i < arguments.length && i < argumentVariables.size(); i++) {
       Object[] var = arguments[i];
       if (var.length == 0) continue;
-      argumentVariables.get(i).change(sectionEvent, arguments[i], Changer.ChangeMode.SET);
+      argumentVariables.get(i).change(sectionEvent, var, Changer.ChangeMode.SET);
     }
 
     TriggerItem.walk(trigger, sectionEvent);

--- a/src/main/java/com/btk5h/skriptmirror/skript/reflect/sections/Section.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/reflect/sections/Section.java
@@ -32,10 +32,11 @@ public class Section {
     SkriptReflection.putLocals(SkriptReflection.copyLocals(variablesMap), sectionEvent);
 
     for (int i = 0; i < arguments.length && i < argumentVariables.size(); i++) {
-      Object[] var = arguments[i];
-      if (var.length == 0) continue;
-      argumentVariables.get(i).change(sectionEvent, var, Changer.ChangeMode.SET);
-    }
+			Object[] currentArg = arguments[i];
+			argumentVariables.get(i).change(sectionEvent, currentArg,
+					currentArg.length != 0 ? Changer.ChangeMode.SET : Changer.ChangeMode.DELETE
+			);
+		}
 
     TriggerItem.walk(trigger, sectionEvent);
     SkriptReflection.removeLocals(sectionEvent);

--- a/src/main/java/com/btk5h/skriptmirror/skript/reflect/sections/Section.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/reflect/sections/Section.java
@@ -33,9 +33,11 @@ public class Section {
 
     for (int i = 0; i < arguments.length && i < argumentVariables.size(); i++) {
 			Object[] currentArg = arguments[i];
-			argumentVariables.get(i).change(sectionEvent, currentArg,
-					currentArg.length != 0 ? Changer.ChangeMode.SET : Changer.ChangeMode.DELETE
-			);
+      if (currentArg.length == 0) {
+        argumentVariables.get(i).change(sectionEvent, null, Changer.ChangeMode.DELETE);
+      } else {
+        argumentVariables.get(i).change(sectionEvent, currentArg, Changer.ChangeMode.SET);
+      }
 		}
 
     TriggerItem.walk(trigger, sectionEvent);

--- a/src/main/java/com/btk5h/skriptmirror/skript/reflect/sections/Section.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/reflect/sections/Section.java
@@ -32,6 +32,8 @@ public class Section {
     SkriptReflection.putLocals(SkriptReflection.copyLocals(variablesMap), sectionEvent);
 
     for (int i = 0; i < arguments.length && i < argumentVariables.size(); i++) {
+      Object[] var = arguments[i];
+      if (var.length == 0) continue;
       argumentVariables.get(i).change(sectionEvent, arguments[i], Changer.ChangeMode.SET);
     }
 


### PR DESCRIPTION
```
[13:21:00 WARN]: org.apache.commons.lang.UnhandledException: Plugin skript-reflect v2.3 generated an exception while executing task 6
        at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:56)
        at org.github.paperspigot.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:23)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1623)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
        at ch.njol.skript.lang.Variable.change(Variable.java:517)
        at com.btk5h.skriptmirror.skript.reflect.sections.Section.run(Section.java:36)
        at com.btk5h.skriptmirror.skript.reflect.sections.EffRunSection.lambda$walk$2(EffRunSection.java:92)
        at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftTask.run(CraftTask.java:59)
        at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:53)
        ... 4 more
```

```
on load:
    create new section with {_request} stored in {test}:
        if {_request} is not set:
            return false
        
        return true
    run section {test} async with {_n} and store result in {_result} and wait
    broadcast "Result: %{_result}%"
```

Tested in old and latest version (1.20.4) - in both the error exists.
This pr fixes that 