### PR TITLE
2.9 support

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 group 'com.btk5h.skript-mirror'
-version '2.4'
+version '2.5'
 
 apply plugin: 'java'
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,6 @@ compileJava   {
 
 dependencies {
   implementation 'org.spigotmc:spigot-api:1.13.2-R0.1-SNAPSHOT'
-  implementation 'com.github.SkriptLang:Skript:2.8.0'
+  implementation 'com.github.SkriptLang:Skript:2.9.0'
   implementation 'org.eclipse.jdt:org.eclipse.jdt.annotation:1.1.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ processResources {
 }
 
 compileJava   {
-  sourceCompatibility = '1.11'
-  targetCompatibility = '1.11'
+  sourceCompatibility = '11'
+  targetCompatibility = '11'
   options.encoding = 'UTF-8'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ processResources {
 }
 
 compileJava   {
-  sourceCompatibility = '1.8'
-  targetCompatibility = '1.8'
+  sourceCompatibility = '1.11'
+  targetCompatibility = '1.11'
   options.encoding = 'UTF-8'
 }
 

--- a/src/main/java/org/skriptlang/reflect/java/elements/events/EvtByReflection.java
+++ b/src/main/java/org/skriptlang/reflect/java/elements/events/EvtByReflection.java
@@ -132,6 +132,9 @@ public class EvtByReflection extends SkriptEvent {
     boolean hasUncancellable = false;
     boolean hasCancellable = false;
 
+    if (classes == null)
+      return new Class[]{BukkitEvent.class};
+
     for (Class<? extends Event> eventClass : classes) {
       if (Cancellable.class.isAssignableFrom(eventClass)) {
         hasCancellable = true;


### PR DESCRIPTION
adds fallback for getEventClasses before init and bumps version
adds support for the new listener behavior api

reflect 2.5 will require skript 2.9+