### PR TITLE
Replace 'the raw %objects%' with a less conflicting syntax

### DIFF
--- a/src/main/java/com/btk5h/skriptmirror/skript/custom/ExprRawExpression.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/custom/ExprRawExpression.java
@@ -1,10 +1,10 @@
 package com.btk5h.skriptmirror.skript.custom;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.classes.Changer;
+import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import com.btk5h.skriptmirror.WrappedEvent;
@@ -15,16 +15,27 @@ import org.bukkit.event.Event;
 public class ExprRawExpression extends SimpleExpression<Expression> {
   static {
     Skript.registerExpression(ExprRawExpression.class, Expression.class, ExpressionType.COMBINED,
+        "[the] (raw|underlying) expression[s] of %objects%",
+        "%objects%'[s] (raw|underlying) expression[s]",
         "[the] raw [expression] %objects%");
   }
 
   private Expression<?> expr;
 
   @Override
-  protected Expression[] get(Event e) {
+  public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+    if (matchedPattern == 2)
+      Skript.warning("Using 'raw %objects%' is deprecated, please use 'the (raw|underlying) expression of %objects%' instead. " +
+          "If you meant to use Skript's 'raw %strings%' expression, try 'raw string within %objects%'.");
+    expr = SkriptUtil.defendExpression(exprs[0]);
+    return SkriptUtil.canInitSafely(expr);
+  }
+
+  @Override
+  protected Expression<?>[] get(Event event) {
     Expression<?> expr = this.expr;
-    if (expr instanceof ExprExpression && e instanceof CustomSyntaxEvent) {
-      expr = ((ExprExpression) expr).getExpression(e);
+    if (expr instanceof ExprExpression<?> exprExpr && event instanceof CustomSyntaxEvent) {
+      expr = exprExpr.getExpression(event);
       if (expr == null)
         return null;
       expr = expr.getSource();
@@ -33,22 +44,12 @@ public class ExprRawExpression extends SimpleExpression<Expression> {
   }
 
   @Override
-  public boolean isSingle() {
-    return true;
-  }
-
-  @Override
-  public Class<? extends Expression> getReturnType() {
-    return Expression.class;
-  }
-
-  @Override
-  public Class<?>[] acceptChange(Changer.ChangeMode changeMode) {
+  public Class<?>[] acceptChange(ChangeMode changeMode) {
     return expr instanceof ExprExpression ? new Class[] {Object[].class} : null;
   }
 
   @Override
-  public void change(Event event, Object[] delta, Changer.ChangeMode changeMode) {
+  public void change(Event event, Object[] delta, ChangeMode changeMode) {
     if (!(expr instanceof ExprExpression && event instanceof CustomSyntaxEvent))
       return;
 
@@ -68,14 +69,19 @@ public class ExprRawExpression extends SimpleExpression<Expression> {
   }
 
   @Override
-  public String toString(Event event, boolean debug) {
-    return "raw " + expr.toString(event, debug);
+  public boolean isSingle() {
+    return true;
   }
 
   @Override
-  public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed,
-                      SkriptParser.ParseResult parseResult) {
-    expr = SkriptUtil.defendExpression(exprs[0]);
-    return SkriptUtil.canInitSafely(expr);
+  @SuppressWarnings("rawtypes")
+  public Class<? extends Expression> getReturnType() {
+    return Expression.class;
   }
+
+  @Override
+  public String toString(Event event, boolean debug) {
+    return "the underlying expression of " + expr.toString(event, debug);
+  }
+
 }


### PR DESCRIPTION
Replaces `[the] raw [expression] %objects%` with `[the] (raw|underlying) expression[s] of %objects%` and `%objects%'[s] (raw|underlying) expression[s]`. The aim is to reduce ambiguity and conflicts with other syntaxes, like `raw gold` and Skript's `raw %strings%` expression. The previous syntax is still functional, but will produce warnings when parsed to give users a chance to update without having scripts break.

This will require an update to the documentation.