### PR TITLE
Lower ExprRawExpression Priority

### DIFF
--- a/src/main/java/com/btk5h/skriptmirror/skript/custom/ExprRawExpression.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/custom/ExprRawExpression.java
@@ -14,7 +14,7 @@ import org.bukkit.event.Event;
 
 public class ExprRawExpression extends SimpleExpression<Expression> {
   static {
-    Skript.registerExpression(ExprRawExpression.class, Expression.class, ExpressionType.COMBINED,
+    Skript.registerExpression(ExprRawExpression.class, Expression.class, ExpressionType.PATTERN_MATCHES_EVERYTHING,
         "[the] (raw|underlying) expression[s] of %objects%",
         "%objects%'[s] (raw|underlying) expression[s]",
         "[the] raw [expression] %objects%");


### PR DESCRIPTION
to properly avoid conflicts with 2.12+, raw expr needs to use a lower priority until the conflicting pattern is fully removed. This is a breaking change, however, as cases like `raw expr-1` will parse as the raw string expression. Expressions with return types that can't be strings will be parsed correctly, however.