### PR TITLE
Improve return types for ExprExpression and ExprChangeValue

### DIFF
--- a/src/main/java/com/btk5h/skriptmirror/skript/custom/ExprExpression.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/custom/ExprExpression.java
@@ -1,64 +1,36 @@
 package com.btk5h.skriptmirror.skript.custom;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.classes.Changer;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
-import ch.njol.skript.log.ErrorQuality;
 import ch.njol.skript.util.Utils;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
-import ch.njol.util.coll.iterator.ArrayIterator;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.reflect.syntax.condition.ConditionCheckEvent;
 import org.skriptlang.reflect.syntax.effect.EffectTriggerEvent;
 import org.skriptlang.reflect.syntax.event.EventTriggerEvent;
 import org.skriptlang.reflect.syntax.expression.ExpressionChangeEvent;
 import org.skriptlang.reflect.syntax.expression.ExpressionGetEvent;
-import com.btk5h.skriptmirror.util.JavaUtil;
 import org.bukkit.event.Event;
-import org.skriptlang.skript.lang.converter.Converters;
 
-import java.util.Iterator;
-import java.util.function.Predicate;
+import java.lang.reflect.Array;
+import java.util.Arrays;
 
-public class ExprExpression<T> implements Expression<T> {
+public class ExprExpression extends SimpleExpression<Object> {
+
 	static {
-		//noinspection unchecked
 		Skript.registerExpression(ExprExpression.class, Object.class, ExpressionType.SIMPLE,
-			"[the] expr[ession][(1¦s)](-| )<\\d+>");
+			"[the] expr[ession][plural:s](-| )<\\d+>");
 	}
 
 	private int index;
-	private boolean plural;
-
-	private final ExprExpression<?> source;
-	private final Class<? extends T>[] types;
-	private final Class<T> superType;
-
-	@SuppressWarnings("unchecked")
-	public ExprExpression() {
-		this(null, ((Class<? extends T>) Object.class));
-	}
-
-	@SuppressWarnings("unchecked")
-	@SafeVarargs
-	private ExprExpression(ExprExpression<?> source, Class<? extends T>... types) {
-		if (source != null) {
-			index = source.index;
-			plural = source.plural;
-		}
-
-		this.source = source;
-		this.types = types;
-		this.superType = (Class<T>) Utils.getSuperType(types);
-	}
+	private boolean isPlural;
+	private Class<?> returnType;
 
 	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed,
-						SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		if (!getParser().isCurrentEvent(
 			SyntaxParseEvent.class,
 			ConditionCheckEvent.class,
@@ -67,51 +39,38 @@ public class ExprExpression<T> implements Expression<T> {
 			ExpressionChangeEvent.class,
 			ExpressionGetEvent.class
 		)) {
-			Skript.error("The expression 'expression' may only be used in a custom syntax.",
-				ErrorQuality.SEMANTIC_ERROR);
+			Skript.error("The expression 'expression' may only be used in a custom syntax structure");
 			return false;
 		}
 
-		index = Utils.parseInt(parseResult.regexes.get(0).group(0));
+		index = Utils.parseInt(parseResult.regexes.getFirst().group(0));
 		if (index <= 0) {
-			Skript.error("The expression index must be a natural number.", ErrorQuality.SEMANTIC_ERROR);
+			Skript.error("The expression index must be a natural number");
 			return false;
 		}
 		index--;
 
-		plural = parseResult.mark == 1;
+		isPlural = parseResult.hasTag("plural");
+
+		// TODO better return types
+		returnType = Object.class;
 
 		return true;
 	}
 
 	@Override
-	public T getSingle(Event e) {
-		T[] all = getAll(e);
-		if (all.length == 0) {
-			return null;
-		}
-		return all[0];
-	}
-
-	@Override
-	public T[] getArray(Event e) {
-		return getAll(e);
-	}
-
-	@Override
-	public T[] getAll(Event e) {
-		Expression<?> expr = getExpression(e);
-
+	protected Object @Nullable [] get(Event event) {
+		Expression<?> expr = getExpression(event);
 		if (expr == null) {
-			return JavaUtil.newArray(superType, 0);
+			return (Object[]) Array.newInstance(getReturnType(), 0);
 		}
-
-		return Converters.convert(expr.getAll(e), types, superType);
+		Object[] values = expr.getAll(event);
+		return Arrays.copyOf(values, values.length, (Class<? extends Object[]>) getReturnType().arrayType());
 	}
 
 	@Nullable
-	Expression<?> getExpression(Event e) {
-		Expression<?>[] expressions = ((CustomSyntaxEvent) e).getExpressions();
+	Expression<?> getExpression(Event event) {
+		Expression<?>[] expressions = ((CustomSyntaxEvent) event).getExpressions();
 		if (index < expressions.length) {
 			return expressions[index];
 		}
@@ -120,87 +79,17 @@ public class ExprExpression<T> implements Expression<T> {
 
 	@Override
 	public boolean isSingle() {
-		return !plural;
+		return !isPlural;
 	}
 
 	@Override
-	public boolean check(Event e, Predicate<? super T> c, boolean negated) {
-		return SimpleExpression.check(getAll(e), c, negated, getAnd());
+	public Class<?> getReturnType() {
+		return returnType;
 	}
 
 	@Override
-	public boolean check(Event e, Predicate<? super T> c) {
-		return SimpleExpression.check(getAll(e), c, false, getAnd());
-	}
-
-	@Override
-	public <R> Expression<? extends R> getConvertedExpression(Class<R>[] to) {
-		return new ExprExpression<>(this, to);
-	}
-
-	@Override
-	public Class<? extends T> getReturnType() {
-		return superType;
-	}
-
-	@Override
-	public boolean getAnd() {
-		return true;
-	}
-
-	@Override
-	public boolean setTime(int time) {
-		return false;
-	}
-
-	@Override
-	public int getTime() {
-		return 0;
-	}
-
-	@Override
-	public boolean isDefault() {
-		return false;
-	}
-
-	@Override
-	public Iterator<? extends T> iterator(Event e) {
-		return new ArrayIterator<>(getAll(e));
-	}
-
-	@Override
-	public boolean isLoopOf(String s) {
-		return s.equalsIgnoreCase("expression");
-	}
-
-	@Override
-	public Expression<?> getSource() {
-		return source == null ? this : source;
-	}
-
-	@Override
-	public Expression<? extends T> simplify() {
-		return this;
-	}
-
-	@Override
-	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
-		return null;
-	}
-
-	@Override
-	public void change(Event e, Object[] delta, Changer.ChangeMode mode) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String toString(Event e, boolean debug) {
+	public String toString(Event event, boolean debug) {
 		return "expression " + (index + 1);
-	}
-
-	@Override
-	public String toString() {
-		return toString(null, false);
 	}
 
 }

--- a/src/main/java/com/btk5h/skriptmirror/skript/custom/ExprRawExpression.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/custom/ExprRawExpression.java
@@ -34,7 +34,7 @@ public class ExprRawExpression extends SimpleExpression<Expression> {
 	@Override
 	protected Expression<?>[] get(Event event) {
 		Expression<?> expr = this.expr;
-		if (expr instanceof ExprExpression<?> exprExpr && event instanceof CustomSyntaxEvent) {
+		if (expr instanceof ExprExpression exprExpr && event instanceof CustomSyntaxEvent) {
 			expr = exprExpr.getExpression(event);
 			if (expr == null)
 				return null;
@@ -50,15 +50,15 @@ public class ExprRawExpression extends SimpleExpression<Expression> {
 
 	@Override
 	public void change(Event event, Object[] delta, ChangeMode changeMode) {
-		if (!(expr instanceof ExprExpression && event instanceof CustomSyntaxEvent))
+		if (!(expr instanceof ExprExpression exprExpression && event instanceof CustomSyntaxEvent customEvent))
 			return;
 
-		Expression<?> expr = ((ExprExpression<?>) this.expr).getExpression(event);
+		Expression<?> expr = exprExpression.getExpression(event);
 		if (expr == null)
 			return;
 		Expression<?> source = expr.getSource();
 
-		Event unwrappedEvent = ((WrappedEvent) event).getDirectEvent();
+		Event unwrappedEvent = customEvent.getDirectEvent();
 		// Ensure acceptChange has been called before change
 		try {
 			source.acceptChange(changeMode);

--- a/src/main/java/org/skriptlang/reflect/syntax/expression/elements/ExprChangeValue.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/expression/elements/ExprChangeValue.java
@@ -32,15 +32,9 @@ public class ExprChangeValue extends SimpleExpression<Object> {
 		}
 
 		isPlural = parseResult.hasTag("plural");
+
+		// TODO better return type
 		returnType = Object.class;
-		if (parser.getCurrentStructure() instanceof StructCustomExpression structCustomExpression) {
-			if (structCustomExpression.returnType != null) {
-				returnType = structCustomExpression.returnType;
-				if (returnType.isArray()) {
-					returnType = returnType.getComponentType();
-				}
-			}
-		}
 
 		return true;
 	}

--- a/src/main/java/org/skriptlang/reflect/syntax/expression/elements/ExprChangeValue.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/expression/elements/ExprChangeValue.java
@@ -1,175 +1,72 @@
 package org.skriptlang.reflect.syntax.expression.elements;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.classes.Changer;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.parser.ParserInstance;
 import ch.njol.skript.lang.util.SimpleExpression;
-import ch.njol.skript.log.ErrorQuality;
-import ch.njol.skript.util.Utils;
 import ch.njol.util.Kleenean;
-import ch.njol.util.coll.iterator.ArrayIterator;
-import com.btk5h.skriptmirror.util.JavaUtil;
 import org.bukkit.event.Event;
 import org.skriptlang.reflect.syntax.expression.ExpressionChangeEvent;
-import org.skriptlang.skript.lang.converter.Converters;
 
-import java.util.Iterator;
-import java.util.function.Predicate;
+import java.lang.reflect.Array;
+import java.util.Arrays;
 
-public class ExprChangeValue<T> implements Expression<T> {
+public class ExprChangeValue extends SimpleExpression<Object> {
+
 	static {
-		//noinspection unchecked
 		Skript.registerExpression(ExprChangeValue.class, Object.class, ExpressionType.SIMPLE,
-			"[the] change value[1:s]");
+			"[the] change value[plural:s]");
 	}
 
-	private int index;
-	private boolean plural;
+	private boolean isPlural;
+	private Class<?> returnType;
 
-	private final ExprChangeValue<?> source;
-	private final Class<? extends T>[] types;
-	private final Class<T> superType;
-
-	@SuppressWarnings("unchecked")
-	public ExprChangeValue() {
-		this(null, ((Class<? extends T>) Object.class));
-	}
-
-	@SuppressWarnings("unchecked")
-	@SafeVarargs
-	private ExprChangeValue(ExprChangeValue<?> source, Class<? extends T>... types) {
-		if (source != null) {
-			index = source.index;
-			plural = source.plural;
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		ParserInstance parser = getParser();
+		if (!parser.isCurrentEvent(ExpressionChangeEvent.class)) {
+			Skript.error("The change value may only be used in a change handler");
+			return false;
 		}
 
-		this.source = source;
-		this.types = types;
-		this.superType = (Class<T>) Utils.getSuperType(types);
-	}
-
-	@Override
-	public T getSingle(Event e) {
-		T[] all = getAll(e);
-		if (all.length == 0) {
-			return null;
+		isPlural = parseResult.hasTag("plural");
+		returnType = Object.class;
+		if (parser.getCurrentStructure() instanceof StructCustomExpression structCustomExpression) {
+			if (structCustomExpression.returnType != null) {
+				returnType = structCustomExpression.returnType;
+				if (returnType.isArray()) {
+					returnType = returnType.getComponentType();
+				}
+			}
 		}
-		return all[0];
+
+		return true;
 	}
 
 	@Override
-	public T[] getArray(Event e) {
-		return getAll(e);
-	}
-
-	@Override
-	public T[] getAll(Event e) {
-		Object[] delta = ((ExpressionChangeEvent) e).getDelta();
+	protected Object[] get(Event event) {
+		Object[] delta = ((ExpressionChangeEvent) event).getDelta();
 		if (delta == null) {
-			return JavaUtil.newArray(superType, 0);
+			return (Object[]) Array.newInstance(getReturnType(), 0);
 		}
-		return Converters.convert(delta, types, superType);
+		return Arrays.copyOf(delta, delta.length, (Class<? extends Object[]>) getReturnType().arrayType());
 	}
 
 	@Override
 	public boolean isSingle() {
-		return !plural;
+		return !isPlural;
 	}
 
 	@Override
-	public boolean check(Event e, Predicate<? super T> c, boolean negated) {
-		return SimpleExpression.check(getAll(e), c, negated, getAnd());
+	public Class<?> getReturnType() {
+		return returnType;
 	}
 
 	@Override
-	public boolean check(Event e, Predicate<? super T> c) {
-		return SimpleExpression.check(getAll(e), c, false, getAnd());
+	public String toString(Event event, boolean debug) {
+		return "the change value" + (isPlural ? "s" : "");
 	}
 
-	@Override
-	public <R> Expression<? extends R> getConvertedExpression(Class<R>[] to) {
-		return new ExprChangeValue<>(this, to);
-	}
-
-	@Override
-	public Class<? extends T> getReturnType() {
-		return superType;
-	}
-
-	@Override
-	public boolean getAnd() {
-		return true;
-	}
-
-	@Override
-	public boolean setTime(int time) {
-		return false;
-	}
-
-	@Override
-	public int getTime() {
-		return 0;
-	}
-
-	@Override
-	public boolean isDefault() {
-		return false;
-	}
-
-	@Override
-	public Iterator<? extends T> iterator(Event e) {
-		return new ArrayIterator<>(getAll(e));
-	}
-
-	@Override
-	public boolean isLoopOf(String s) {
-		return s.equalsIgnoreCase("expression");
-	}
-
-	@Override
-	public Expression<?> getSource() {
-		return source == null ? this : source;
-	}
-
-	@Override
-	public Expression<? extends T> simplify() {
-		return this;
-	}
-
-	@Override
-	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
-		return null;
-	}
-
-	@Override
-	public void change(Event e, Object[] delta, Changer.ChangeMode mode) {
-		throw new UnsupportedOperationException();
-	}
-
-
-	@Override
-	public String toString(Event e, boolean debug) {
-		return "expression " + index;
-	}
-
-	@Override
-	public String toString() {
-		return toString(null, false);
-	}
-
-	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed,
-						SkriptParser.ParseResult parseResult) {
-		if (!getParser().isCurrentEvent(ExpressionChangeEvent.class)) {
-			Skript.error("The change value may only be used in a change handlers.",
-				ErrorQuality.SEMANTIC_ERROR);
-			return false;
-		}
-
-		plural = parseResult.mark == 1;
-
-		return true;
-	}
 }

--- a/src/main/java/org/skriptlang/reflect/syntax/expression/elements/StructCustomExpression.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/expression/elements/StructCustomExpression.java
@@ -109,6 +109,7 @@ public class StructCustomExpression extends CustomSyntaxStructure<ExpressionSynt
 
 	private final Map<ChangeMode, SectionNode> changerNodes = new HashMap<>();
 	private SectionNode parseNode;
+	@Nullable Class<?> returnType;
 
 	@Override
 	protected DataTracker<ExpressionSyntaxInfo> getDataTracker() {
@@ -188,6 +189,7 @@ public class StructCustomExpression extends CustomSyntaxStructure<ExpressionSynt
 		Class<?> returnType = entryContainer.getOptional("return type", Class.class, false);
 		if (returnType != null)
 			whichInfo.forEach(which -> returnTypes.put(which, returnType));
+		this.returnType = returnType;
 
 		String loopOf = entryContainer.getOptional("loop of", String.class, false);
 		if (loopOf != null)

--- a/src/main/java/org/skriptlang/reflect/syntax/expression/elements/StructCustomExpression.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/expression/elements/StructCustomExpression.java
@@ -109,7 +109,6 @@ public class StructCustomExpression extends CustomSyntaxStructure<ExpressionSynt
 
 	private final Map<ChangeMode, SectionNode> changerNodes = new HashMap<>();
 	private SectionNode parseNode;
-	@Nullable Class<?> returnType;
 
 	@Override
 	protected DataTracker<ExpressionSyntaxInfo> getDataTracker() {
@@ -189,7 +188,6 @@ public class StructCustomExpression extends CustomSyntaxStructure<ExpressionSynt
 		Class<?> returnType = entryContainer.getOptional("return type", Class.class, false);
 		if (returnType != null)
 			whichInfo.forEach(which -> returnTypes.put(which, returnType));
-		this.returnType = returnType;
 
 		String loopOf = entryContainer.getOptional("loop of", String.class, false);
 		if (loopOf != null)


### PR DESCRIPTION
This pull request aims to improve the return types for `ExprExpression` and `ExprChangeValue`. On Skript 2.14, they do not work well with property syntax. They use the outdated (and potentially dangerous) approach of typing themselves. This causes unexpected behavior, such as property syntaxes not working with expressions that should be supported.

To resolve this, I have rewritten both of the expressions. For now, only use as Object return type as the current setup prevents determining this information without more significant changes (and it won't really have a big impact)