### PR TITLE
Fix Version Check Failure Caused by nightly Postfix

### DIFF
--- a/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
+++ b/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
@@ -44,7 +44,7 @@ public class SkriptMirror extends JavaPlugin {
 			return;
 		}
 
-		if (Skript.getVersion().isSmallerThan(new Version(2, 14))) {
+		if (Skript.getVersion().compareTo(new Version(2, 14)) <= 0) {
 			getLogger().severe("");
 			getLogger().severe("Your version of Skript (" + Skript.getVersion() + ") is not supported, at least Skript 2.14 is required to run this version of skript-reflect.");
 			getLogger().severe("");

--- a/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
+++ b/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
@@ -47,7 +47,8 @@ public class SkriptMirror extends JavaPlugin {
 		Version minVersion = new Version(2, 14);
 		// Skip post fix checks
 		if (currentVersion.getMajor() < minVersion.getMajor()
-		|| (currentVersion.getMajor() == minVersion.getMajor() && currentVersion.getMinor() < minVersion.getMinor())) {
+		|| (currentVersion.getMajor() == minVersion.getMajor() && currentVersion.getMinor() < minVersion.getMinor())
+	    || (currentVersion.getMajor() == minVersion.getMajor() && currentVersion.getMinor() == minVersion.getMinor() && currentVersion.getRevision() < minVersion.getRevision())) {
 			getLogger().severe("");
 			getLogger().severe("Your version of Skript (" + currentVersion + ") is not supported, at least Skript 2.14 is required to run this version of skript-reflect.");
 			getLogger().severe("");

--- a/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
+++ b/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
@@ -43,10 +43,13 @@ public class SkriptMirror extends JavaPlugin {
 			Bukkit.getPluginManager().disablePlugin(this);
 			return;
 		}
-
-		if (Skript.getVersion().isSmallerThan(new Version(2, 14))) {
+		Version currentVersion = Skript.getVersion();
+		Version minVersion = new Version(2, 14);
+		// Skip post fix checks
+		if (currentVersion.getMajor() < minVersion.getMajor()
+		|| (currentVersion.getMajor() == minVersion.getMajor() && currentVersion.getMinor() < minVersion.getMinor())) {
 			getLogger().severe("");
-			getLogger().severe("Your version of Skript (" + Skript.getVersion() + ") is not supported, at least Skript 2.14 is required to run this version of skript-reflect.");
+			getLogger().severe("Your version of Skript (" + currentVersion + ") is not supported, at least Skript 2.14 is required to run this version of skript-reflect.");
 			getLogger().severe("");
 			Bukkit.getPluginManager().disablePlugin(this);
 			return;

--- a/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
+++ b/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
@@ -44,7 +44,7 @@ public class SkriptMirror extends JavaPlugin {
 			return;
 		}
 
-		if (Skript.getVersion().isSmallerThan(new Version("2.14.0-pre1"))) {
+		if (Skript.getVersion().isSmallerThan(new Version(2, 14))) {
 			getLogger().severe("");
 			getLogger().severe("Your version of Skript (" + Skript.getVersion() + ") is not supported, at least Skript 2.14 is required to run this version of skript-reflect.");
 			getLogger().severe("");

--- a/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
+++ b/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
@@ -44,7 +44,7 @@ public class SkriptMirror extends JavaPlugin {
 			return;
 		}
 
-		if (Skript.getVersion().compareTo(new Version(2, 14)) <= 0) {
+		if (Skript.getVersion().compareTo(new Version(2, 14)) >= 0) {
 			getLogger().severe("");
 			getLogger().severe("Your version of Skript (" + Skript.getVersion() + ") is not supported, at least Skript 2.14 is required to run this version of skript-reflect.");
 			getLogger().severe("");

--- a/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
+++ b/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
@@ -44,7 +44,7 @@ public class SkriptMirror extends JavaPlugin {
 			return;
 		}
 
-		if (Skript.getVersion().compareTo(new Version(2, 14)) >= 0) {
+		if (Skript.getVersion().isSmallerThan(new Version(2, 14))) {
 			getLogger().severe("");
 			getLogger().severe("Your version of Skript (" + Skript.getVersion() + ") is not supported, at least Skript 2.14 is required to run this version of skript-reflect.");
 			getLogger().severe("");


### PR DESCRIPTION
# Problem

If Skript version contains postfix `nightly`, current version check does not work.
Also `quickTest` action creates postfix `nightly`, which is why, the current tests are failing. 

# Solution 

Use stable.