### PR TITLE
Improve ExpressionStatement parsing, lower priority for ExprJavaCall/ExprCustomEventValue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,5 @@ tasks.withType(JavaCompile).configureEach {
 
 dependencies {
 	compileOnly group: 'io.papermc.paper', name: 'paper-api', version: '1.21.10-R0.1-SNAPSHOT'
-	compileOnly group: 'com.github.SkriptLang', name: 'Skript', version: '2.14.0-pre1'
+	compileOnly group: 'com.github.SkriptLang', name: 'Skript', version: '2.14.0'
 }

--- a/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
+++ b/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
@@ -50,7 +50,7 @@ public class SkriptMirror extends JavaPlugin {
 			return;
 		}
 
-		if (Skript.getVersion().isSmallerThan(new Version("2.14.0-pre1"))) {
+		if (Skript.getVersion().isLargerThan(new Version("2.13.2"))) {
 			getLogger().severe("");
 			getLogger().severe("Your version of Skript (" + Skript.getVersion() + ") is not supported, at least Skript 2.14 is required to run this version of skript-reflect.");
 			getLogger().severe("");

--- a/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
+++ b/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
@@ -15,11 +15,13 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.skriptlang.reflect.syntax.condition.elements.StructCustomCondition;
 import org.skriptlang.reflect.syntax.effect.elements.StructCustomEffect;
+import org.skriptlang.reflect.syntax.event.elements.ExprCustomEventValue;
 import org.skriptlang.reflect.syntax.event.elements.StructCustomEvent;
 import org.skriptlang.reflect.syntax.expression.elements.StructCustomExpression;
 import org.skriptlang.skript.lang.comparator.Comparators;
 import org.skriptlang.skript.lang.comparator.Relation;
 import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 import org.skriptlang.skript.util.Priority;
 
 import java.io.IOException;
@@ -67,9 +69,11 @@ public class SkriptMirror extends JavaPlugin {
 				.loadClasses("com.btk5h.skriptmirror.skript")
 				.loadClasses("org.skriptlang.reflect", "syntax", "java.elements");
 
-			ExprJavaCall.register(addonInstance.syntaxRegistry());
-			CondExpressionStatement.register(addonInstance.syntaxRegistry());
-			EffExpressionStatement.register(addonInstance.syntaxRegistry());
+			SyntaxRegistry registry = addonInstance.syntaxRegistry();
+			ExprCustomEventValue.register(registry);
+			ExprJavaCall.register(registry);
+			CondExpressionStatement.register(registry);
+			EffExpressionStatement.register(registry);
 
 			Path dataFolder = SkriptMirror.getInstance().getDataFolder().toPath();
 			LibraryLoader.loadLibraries(dataFolder);

--- a/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
+++ b/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
@@ -50,7 +50,7 @@ public class SkriptMirror extends JavaPlugin {
 			return;
 		}
 
-		if (Skript.getVersion().isLargerThan(new Version("2.13.2"))) {
+		if (!Skript.getVersion().isLargerThan(new Version("2.13.2"))) {
 			getLogger().severe("");
 			getLogger().severe("Your version of Skript (" + Skript.getVersion() + ") is not supported, at least Skript 2.14 is required to run this version of skript-reflect.");
 			getLogger().severe("");

--- a/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
+++ b/src/main/java/com/btk5h/skriptmirror/SkriptMirror.java
@@ -5,18 +5,22 @@ import ch.njol.skript.SkriptAddon;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.Version;
-import org.skriptlang.reflect.syntax.condition.elements.StructCustomCondition;
-import org.skriptlang.reflect.syntax.effect.elements.StructCustomEffect;
-import org.skriptlang.reflect.syntax.event.elements.StructCustomEvent;
-import org.skriptlang.reflect.syntax.expression.elements.StructCustomExpression;
+import com.btk5h.skriptmirror.skript.CondExpressionStatement;
+import com.btk5h.skriptmirror.skript.EffExpressionStatement;
 import com.btk5h.skriptmirror.skript.reflect.ExprJavaCall;
 import com.btk5h.skriptmirror.skript.reflect.ExprProxy;
 import com.btk5h.skriptmirror.skript.reflect.sections.SecSection;
 import com.btk5h.skriptmirror.util.SkriptReflection;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.skriptlang.reflect.syntax.condition.elements.StructCustomCondition;
+import org.skriptlang.reflect.syntax.effect.elements.StructCustomEffect;
+import org.skriptlang.reflect.syntax.event.elements.StructCustomEvent;
+import org.skriptlang.reflect.syntax.expression.elements.StructCustomExpression;
 import org.skriptlang.skript.lang.comparator.Comparators;
 import org.skriptlang.skript.lang.comparator.Relation;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.util.Priority;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -27,6 +31,8 @@ public class SkriptMirror extends JavaPlugin {
 
 	private static SkriptMirror instance;
 	private static SkriptAddon addonInstance;
+
+	public static final Priority SHADOW_REALM = Priority.after(SyntaxInfo.PATTERN_MATCHES_EVERYTHING);
 
 	public SkriptMirror() {
 		if (instance == null) {
@@ -60,6 +66,10 @@ public class SkriptMirror extends JavaPlugin {
 			getAddonInstance()
 				.loadClasses("com.btk5h.skriptmirror.skript")
 				.loadClasses("org.skriptlang.reflect", "syntax", "java.elements");
+
+			ExprJavaCall.register(addonInstance.syntaxRegistry());
+			CondExpressionStatement.register(addonInstance.syntaxRegistry());
+			EffExpressionStatement.register(addonInstance.syntaxRegistry());
 
 			Path dataFolder = SkriptMirror.getInstance().getDataFolder().toPath();
 			LibraryLoader.loadLibraries(dataFolder);

--- a/src/main/java/com/btk5h/skriptmirror/skript/CondExpressionStatement.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/CondExpressionStatement.java
@@ -16,6 +16,8 @@ import com.btk5h.skriptmirror.util.SkriptReflection;
 import com.btk5h.skriptmirror.util.SkriptUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -23,13 +25,19 @@ import java.util.concurrent.Executors;
 
 public class CondExpressionStatement extends Condition {
 
-	static {
-		Skript.registerCondition(CondExpressionStatement.class, "[(1¦await)] %~javaobject%");
+	public static void register(SyntaxRegistry registry) {
+		registry.register(
+			SyntaxRegistry.CONDITION,
+			SyntaxInfo.builder(CondExpressionStatement.class)
+				.addPattern("[1:await] <.+>")
+				.supplier(CondExpressionStatement::new)
+				.priority(SkriptMirror.SHADOW_REALM)
+				.build());
 	}
 
 	private static final ExecutorService threadPool = Executors.newCachedThreadPool();
 
-	private Expression<Object> arg;
+	private Expression<?> arg;
 	private boolean isAsynchronous;
 	private boolean isCondition;
 
@@ -74,10 +82,13 @@ public class CondExpressionStatement extends Condition {
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed,
 						SkriptParser.ParseResult parseResult) {
-		arg = SkriptUtil.defendExpression(exprs[0]);
+		String rawInput = parseResult.regexes.getFirst().group();
+		// parse directly as ExprJavaCall to avoid useless parse attempts
+		arg = ExprJavaCall.parse(rawInput);
 
-		if (!(arg instanceof ExprJavaCall))
+		if (arg == null) {
 			return false;
+		}
 
 		isAsynchronous = (parseResult.mark & 1) == 1;
 		isCondition = SkriptLogger.getNode() instanceof SectionNode;

--- a/src/main/java/com/btk5h/skriptmirror/skript/EffExpressionStatement.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/EffExpressionStatement.java
@@ -1,6 +1,5 @@
 package com.btk5h.skriptmirror.skript;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.effects.Delay;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
@@ -13,20 +12,28 @@ import com.btk5h.skriptmirror.util.SkriptReflection;
 import com.btk5h.skriptmirror.util.SkriptUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class EffExpressionStatement extends Effect {
-	static {
-		Skript.registerEffect(EffExpressionStatement.class, "[(1¦await)] %~javaobject%");
+	public static void register(SyntaxRegistry registry) {
+		registry.register(
+			SyntaxRegistry.EFFECT,
+			SyntaxInfo.builder(EffExpressionStatement.class)
+				.addPattern("[1:await] <.+>")
+				.supplier(EffExpressionStatement::new)
+				.priority(SkriptMirror.SHADOW_REALM)
+				.build());
 	}
 
 	private static final ExecutorService threadPool =
 		Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 
-	private Expression<Object> arg;
+	private Expression<?> arg;
 	private boolean isAsynchronous;
 
 	@Override
@@ -63,9 +70,11 @@ public class EffExpressionStatement extends Effect {
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed,
 						SkriptParser.ParseResult parseResult) {
-		arg = SkriptUtil.defendExpression(exprs[0]);
+		String rawInput = parseResult.regexes.getFirst().group();
+		// parse directly as ExprJavaCall to avoid useless parse attempts
+		arg = ExprJavaCall.parse(rawInput);
 
-		if (!(arg instanceof ExprJavaCall)) {
+		if (arg == null) {
 			return false;
 		}
 

--- a/src/main/java/com/btk5h/skriptmirror/skript/reflect/ExprJavaCall.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/reflect/ExprJavaCall.java
@@ -2,11 +2,13 @@ package com.btk5h.skriptmirror.skript.reflect;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
-import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionList;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.Utils;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.iterator.ArrayIterator;
 import com.btk5h.skriptmirror.Descriptor;
@@ -15,8 +17,7 @@ import com.btk5h.skriptmirror.JavaCallException;
 import com.btk5h.skriptmirror.JavaType;
 import com.btk5h.skriptmirror.Null;
 import com.btk5h.skriptmirror.ObjectWrapper;
-import org.jetbrains.annotations.Nullable;
-import org.skriptlang.reflect.java.elements.structures.StructImport;
+import com.btk5h.skriptmirror.SkriptMirror;
 import com.btk5h.skriptmirror.util.JavaUtil;
 import com.btk5h.skriptmirror.util.LRUCache;
 import com.btk5h.skriptmirror.util.SkriptMirrorUtil;
@@ -24,8 +25,11 @@ import com.btk5h.skriptmirror.util.SkriptUtil;
 import com.btk5h.skriptmirror.util.StringSimilarity;
 import com.btk5h.skriptmirror.util.lookup.LookupGetter;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.converter.Converters;
 import org.skriptlang.skript.lang.script.Script;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -57,7 +61,6 @@ public class ExprJavaCall<T> implements Expression<T> {
 	private static final MethodHandles.Lookup LOOKUP = LookupGetter.getLookup();
 	private static final Object[] NO_ARGS = new Object[0];
 	private static final Descriptor CONSTRUCTOR_DESCRIPTOR = new Descriptor(null, "<init>", null);
-
 	/**
 	 * A regular expression that captures potential descriptors without actually validating the descriptor. This is done
 	 * both for performance reasons and to provide more helpful error messages when using a malformed descriptor.
@@ -67,13 +70,22 @@ public class ExprJavaCall<T> implements Expression<T> {
 		"([^0-9. \\[\\]][^. \\[\\]]*\\b)" +
 		"(\\[[\\w.$, ]*])?";
 
-	static {
-		//noinspection unchecked
-		Skript.registerExpression(ExprJavaCall.class, Object.class,
-			ExpressionType.PATTERN_MATCHES_EVERYTHING,
-			"[(2¦try)] %object%..%string%[\\((1¦[%-objects%])\\)]",
-			"[(2¦try)] %object%.<" + LITE_DESCRIPTOR + ">[\\((1¦[%-objects%])\\)]",
-			"[(2¦try)] [a] new %javatype%\\([%-objects%]\\)");
+	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	static final SyntaxInfo<?> SYNTAX_INFO = SyntaxInfo.Expression.builder(ExprJavaCall.class, Object.class)
+		.addPattern("[2:try] %object%..%string%[\\([1:%-objects%]\\)]")
+		.addPattern("[2:try] %object%.<" + LITE_DESCRIPTOR + ">[\\([1:%-objects%]\\)]")
+		.addPattern("[2:try] [a] new %javatype%\\([%-objects%]\\)")
+		.supplier(ExprJavaCall::new)
+		.priority(SkriptMirror.SHADOW_REALM)
+		.build();
+
+	@SuppressWarnings({"UnstableApiUsage", "rawtypes"})
+	public static void register(SyntaxRegistry registry) {
+		registry.register(SyntaxRegistry.EXPRESSION, (SyntaxInfo.Expression) SYNTAX_INFO);
+	}
+
+	public static @Nullable ExprJavaCall<?> parse(String rawInput) {
+		return (ExprJavaCall<?>) SkriptParser.parse(rawInput, List.of(SYNTAX_INFO).iterator(), null);
 	}
 
 	private enum CallType {

--- a/src/main/java/com/btk5h/skriptmirror/skript/reflect/ExprJavaCall.java
+++ b/src/main/java/com/btk5h/skriptmirror/skript/reflect/ExprJavaCall.java
@@ -72,8 +72,8 @@ public class ExprJavaCall<T> implements Expression<T> {
 
 	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
 	static final SyntaxInfo<?> SYNTAX_INFO = SyntaxInfo.Expression.builder(ExprJavaCall.class, Object.class)
-		.addPattern("[2:try] %object%..%string%[\\([1:%-objects%]\\)]")
-		.addPattern("[2:try] %object%.<" + LITE_DESCRIPTOR + ">[\\([1:%-objects%]\\)]")
+		.addPattern("[2:try] %object%..%string%[\\((1:[%-objects%])\\)]")
+		.addPattern("[2:try] %object%.<" + LITE_DESCRIPTOR + ">[\\((1:[%-objects%])\\)]")
 		.addPattern("[2:try] [a] new %javatype%\\([%-objects%]\\)")
 		.supplier(ExprJavaCall::new)
 		.priority(SkriptMirror.SHADOW_REALM)

--- a/src/main/java/org/skriptlang/reflect/syntax/event/elements/ExprCustomEventValue.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/event/elements/ExprCustomEventValue.java
@@ -4,12 +4,10 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.expressions.base.EventValueExpression;
-import ch.njol.skript.lang.EventRestrictedSyntax;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.Kleenean;
-import ch.njol.util.coll.CollectionUtils;
 import com.btk5h.skriptmirror.SkriptMirror;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
@@ -22,7 +20,7 @@ import org.skriptlang.skript.registration.SyntaxRegistry;
 import java.lang.reflect.Array;
 
 @SuppressWarnings("unused")
-public class ExprCustomEventValue<T> extends EventValueExpression<T> implements EventRestrictedSyntax {
+public class ExprCustomEventValue<T> extends EventValueExpression<T> {
 
 	@SuppressWarnings({"unchecked", "UnstableApiUsage", "RedundantCast", "rawtypes"})
 	public static void register(SyntaxRegistry registry) {
@@ -46,6 +44,9 @@ public class ExprCustomEventValue<T> extends EventValueExpression<T> implements 
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final SkriptParser.ParseResult parseResult) {
+		if (!getParser().isCurrentEvent(BukkitCustomEvent.class, EventTriggerEvent.class))
+			return false;
+
 		EventSyntaxInfo which = CustomEvent.lastWhich;
 		if (which == null)
 			return false;
@@ -106,8 +107,4 @@ public class ExprCustomEventValue<T> extends EventValueExpression<T> implements 
 		return (Class<T>) classInfo.getC();
 	}
 
-	@Override
-	public Class<? extends Event>[] supportedEvents() {
-		return CollectionUtils.array(BukkitCustomEvent.class, EventTriggerEvent.class);
-	}
 }

--- a/src/main/java/org/skriptlang/reflect/syntax/event/elements/ExprCustomEventValue.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/event/elements/ExprCustomEventValue.java
@@ -30,11 +30,11 @@ public class ExprCustomEventValue<T> extends EventValueExpression<T> implements 
 		Skript.registerExpression(ExprCustomEventValue.class, Object.class, ExpressionType.PATTERN_MATCHES_EVERYTHING, "[the] [event-]<.+>");
 	}
 
-	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	@SuppressWarnings({"unchecked", "UnstableApiUsage", "RedundantCast", "rawtypes"})
 	public static void register(SyntaxRegistry registry) {
 		registry.register(
 			SyntaxRegistry.EXPRESSION,
-			SyntaxInfo.Expression.builder(ExprCustomEventValue.class, Object.class)
+			(SyntaxInfo.Expression) SyntaxInfo.Expression.builder(ExprCustomEventValue.class, Object.class)
 				.addPattern("[the] [event-]<.+>")
 				.supplier(ExprCustomEventValue::new)
 				.priority(SkriptMirror.SHADOW_REALM)

--- a/src/main/java/org/skriptlang/reflect/syntax/event/elements/ExprCustomEventValue.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/event/elements/ExprCustomEventValue.java
@@ -6,7 +6,6 @@ import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.EventRestrictedSyntax;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.Kleenean;
@@ -24,11 +23,6 @@ import java.lang.reflect.Array;
 
 @SuppressWarnings("unused")
 public class ExprCustomEventValue<T> extends EventValueExpression<T> implements EventRestrictedSyntax {
-
-	static {
-		//noinspection unchecked
-		Skript.registerExpression(ExprCustomEventValue.class, Object.class, ExpressionType.PATTERN_MATCHES_EVERYTHING, "[the] [event-]<.+>");
-	}
 
 	@SuppressWarnings({"unchecked", "UnstableApiUsage", "RedundantCast", "rawtypes"})
 	public static void register(SyntaxRegistry registry) {

--- a/src/main/java/org/skriptlang/reflect/syntax/event/elements/ExprCustomEventValue.java
+++ b/src/main/java/org/skriptlang/reflect/syntax/event/elements/ExprCustomEventValue.java
@@ -4,25 +4,41 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.expressions.base.EventValueExpression;
+import ch.njol.skript.lang.EventRestrictedSyntax;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import com.btk5h.skriptmirror.SkriptMirror;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.reflect.syntax.event.BukkitCustomEvent;
 import org.skriptlang.reflect.syntax.event.EventSyntaxInfo;
 import org.skriptlang.reflect.syntax.event.EventTriggerEvent;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 import java.lang.reflect.Array;
 
 @SuppressWarnings("unused")
-public class ExprCustomEventValue<T> extends EventValueExpression<T> {
+public class ExprCustomEventValue<T> extends EventValueExpression<T> implements EventRestrictedSyntax {
 
 	static {
 		//noinspection unchecked
 		Skript.registerExpression(ExprCustomEventValue.class, Object.class, ExpressionType.PATTERN_MATCHES_EVERYTHING, "[the] [event-]<.+>");
+	}
+
+	@SuppressWarnings({"unchecked", "UnstableApiUsage"})
+	public static void register(SyntaxRegistry registry) {
+		registry.register(
+			SyntaxRegistry.EXPRESSION,
+			SyntaxInfo.Expression.builder(ExprCustomEventValue.class, Object.class)
+				.addPattern("[the] [event-]<.+>")
+				.supplier(ExprCustomEventValue::new)
+				.priority(SkriptMirror.SHADOW_REALM)
+				.build());
 	}
 
 	private ClassInfo<? super T> classInfo;
@@ -36,8 +52,6 @@ public class ExprCustomEventValue<T> extends EventValueExpression<T> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final SkriptParser.ParseResult parseResult) {
-		if (!getParser().isCurrentEvent(BukkitCustomEvent.class, EventTriggerEvent.class))
-			return false;
 		EventSyntaxInfo which = CustomEvent.lastWhich;
 		if (which == null)
 			return false;
@@ -98,4 +112,8 @@ public class ExprCustomEventValue<T> extends EventValueExpression<T> {
 		return (Class<T>) classInfo.getC();
 	}
 
+	@Override
+	public Class<? extends Event>[] supportedEvents() {
+		return CollectionUtils.array(BukkitCustomEvent.class, EventTriggerEvent.class);
+	}
 }


### PR DESCRIPTION
The ExpressionStatement syntaxes effectively tripled the parse time for every line, as they would match everything and complete the same parse, just to throw it away if it wasn't an ExprJavaCall. Instead, this uses a regex match and then manually parses it using only ExprJavaCall, significantly saving in wasted parse times.

Also, the ExpressionStatement, ExprJavaCall, and ExprCustomEventValue syntaxes have all had their priority reduced to nearly last, to help prevent extraneous parses.

Overall parse times see pretty significant improvements, from 56s to 14s, 20s to 13s, and 16s -> 4s.